### PR TITLE
Delete_cli

### DIFF
--- a/gandalf/train/delete_cli.py
+++ b/gandalf/train/delete_cli.py
@@ -1,0 +1,51 @@
+import pandas as pd
+import argparse
+import shutil
+import os
+
+CHECKPOINT_PATH = 'gandalf/train/checkpoints/train/'
+LOGS_PATH = 'gandalf/train/logs/fit/'
+RESULTS_DATA_PATH = 'gandalf/train/results/data/'
+MODELS_PATH = 'gandalf/train/results/models/'
+TEST_TSNE_PATH = 'gandalf/train/tests/tsne/'
+PATHS = [CHECKPOINT_PATH, LOGS_PATH, RESULTS_DATA_PATH, MODELS_PATH, TEST_TSNE_PATH]
+
+RESULTS_CSV = 'gandalf/train/results/results.csv'
+
+def delete_experiment(id):
+    print("-----------------------------------")
+    print("Deleting experiment with id: ", id)
+
+    dirs = [path + id for path in PATHS]
+
+    for directory in dirs:
+        if not os.path.exists(directory):
+            print(f"Directory {directory} does not exist")
+        else:
+            print(f"Deleting {directory}...")
+            shutil.rmtree(directory)
+
+    print("Deleting row from results.csv...\n")
+    results = pd.read_csv(RESULTS_CSV)
+    results = results[results.model_id != id]
+    results.to_csv(RESULTS_CSV, index=False)
+
+def cli():
+    parser = argparse.ArgumentParser(prog='delete_cli', description='Delete files attached to a experiment id')
+
+    parser.add_argument('ids', metavar='id', type=str, nargs='+',
+                    help='experiment ids to delete')
+    
+    args = parser.parse_args()
+    ids = args.ids
+
+    print("Deleting experiments: ", ids)
+    print("")
+
+    for id in ids:
+        delete_experiment(id)
+
+    print("Done!")
+
+if __name__ == "__main__":
+    cli()

--- a/gandalf/train/delete_cli.py
+++ b/gandalf/train/delete_cli.py
@@ -3,20 +3,20 @@ import argparse
 import shutil
 import os
 
-CHECKPOINT_PATH = 'gandalf/train/checkpoints/train/'
-LOGS_PATH = 'gandalf/train/logs/fit/'
-RESULTS_DATA_PATH = 'gandalf/train/results/data/'
-MODELS_PATH = 'gandalf/train/results/models/'
-TEST_TSNE_PATH = 'gandalf/train/tests/tsne/'
+CHECKPOINT_PATH = 'checkpoints/train/'
+LOGS_PATH = 'logs/fit/'
+RESULTS_DATA_PATH = 'results/data/'
+MODELS_PATH = 'results/models/'
+TEST_TSNE_PATH = 'tests/tsne/'
 PATHS = [CHECKPOINT_PATH, LOGS_PATH, RESULTS_DATA_PATH, MODELS_PATH, TEST_TSNE_PATH]
 
-RESULTS_CSV = 'gandalf/train/results/results.csv'
+RESULTS_CSV_PATH = 'results/results.csv'
 
-def delete_experiment(id):
+def delete_experiment(id, root_folder):
     print("-----------------------------------")
     print("Deleting experiment with id: ", id)
 
-    dirs = [path + id for path in PATHS]
+    dirs = [os.path.normpath(os.path.join(root_folder, path, id)) for path in PATHS]
 
     for directory in dirs:
         if not os.path.exists(directory):
@@ -26,24 +26,28 @@ def delete_experiment(id):
             shutil.rmtree(directory)
 
     print("Deleting row from results.csv...\n")
-    results = pd.read_csv(RESULTS_CSV)
+    results_csv_full_path = os.path.join(root_folder, RESULTS_CSV_PATH)
+    results = pd.read_csv(results_csv_full_path)
     results = results[results.model_id != id]
-    results.to_csv(RESULTS_CSV, index=False)
+    results.to_csv(results_csv_full_path, index=False)
 
 def cli():
     parser = argparse.ArgumentParser(prog='delete_cli', description='Delete files attached to a experiment id')
 
     parser.add_argument('ids', metavar='id', type=str, nargs='+',
                     help='experiment ids to delete')
+    parser.add_argument('--root_folder', type=str, default=os.path.dirname(__file__),
+                        help='root folder where to search for experiments')
     
     args = parser.parse_args()
     ids = args.ids
+    root_folder = args.root_folder
 
     print("Deleting experiments: ", ids)
     print("")
 
     for id in ids:
-        delete_experiment(id)
+        delete_experiment(id, os.path.normpath(root_folder))
 
     print("Done!")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "gandalf"
 
-version = "2.1.3"
+version = "2.2.0"
 
 description = "Generative Adversarial Networks for Disentangling and Learning Framework"
 
@@ -34,6 +34,7 @@ dependencies = [
 [project.scripts]  
 train_cli = "gandalf.train.train_cli:cli"
 test_cli = "gandalf.train.test_cli:cli"
+delete_cli = "gandalf.train.delete_cli:cli"
 
 [tool.setuptools]
 packages = ["gandalf.train"]


### PR DESCRIPTION
Python script to delete performed experiments.

````
usage: delete_cli [-h] id [id ...]

Delete files attached to a experiment id

positional arguments:
  id          experiment ids to delete

options:
  -h, --help  show this help message and exit
````